### PR TITLE
[Backend] Enhancement on history-service and question-service 

### DIFF
--- a/history-service/model/repository.js
+++ b/history-service/model/repository.js
@@ -25,8 +25,8 @@ export async function getHistoryModelByUserId(userId) {
         $or: [
             { userId1: userId },
             { userId2: userId }
-        ]
-    });
+        ],
+    }).sort({ "updatedAt": "desc" });
 }
 
 export async function updateHistoryModel(id, params) {

--- a/question-service/Question-service.postman_collection.json
+++ b/question-service/Question-service.postman_collection.json
@@ -1,0 +1,71 @@
+{
+	"info": {
+		"_postman_id": "46b2f8a6-b894-4d44-9089-4225b0e9d853",
+		"name": "Question-service",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Add new ques",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"title\": \"Candy\",\r\n    \"body\": \"There are n children standing in a line. Each child is assigned a rating value given in the integer array ratings. You are giving candies to these children subjected to the following requirements: Each child must have at least one candy. Children with a higher rating get more candies than their neighbors. Return the minimum number of candies you need to have to distribute the candies to the children. Example 1: Input: ratings = [1,0,2], Output: 5. Explanation: You can allocate to the first, second and third child with 2, 1, 2 candies respectively. Example 2: Input: ratings = [1,2,2], Output: 4. Explanation: You can allocate to the first, second and third child with 1, 2, 1 candies respectively. The third child gets 1 candy because it satisfies the above two conditions.\",\r\n    \"difficulty\": \"hard\",\r\n    \"url\": \"leetcode.com/problems/candy/\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8009/q",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8009",
+					"path": [
+						"q"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get a question",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8009/q/diff?diff=hard",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8009",
+					"path": [
+						"q",
+						"diff"
+					],
+					"query": [
+						{
+							"key": "diff",
+							"value": "hard"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "New Request",
+			"request": {
+				"method": "GET",
+				"header": []
+			},
+			"response": []
+		}
+	]
+}

--- a/question-service/controllers/question-controller.js
+++ b/question-service/controllers/question-controller.js
@@ -13,7 +13,6 @@ export async function createQuestion(req, res) {
             if (resp.err) {
                 return res.status(400).json({ message: 'Could not create a question!' });
             } else {
-                console.log(`Created new question successfully!`)
                 return res.status(201).json({ message: `Created new question successfully!` });
             }
         } else {

--- a/question-service/controllers/question-controller.js
+++ b/question-service/controllers/question-controller.js
@@ -29,7 +29,7 @@ export async function getQuestionByDiff(req, res) {
         const resp = await _getOneQuestionByDifficulty(diff);
         //console.log(resp);
         if (resp.err) {
-            return res.status(400).json({ message: 'Could not get question by diff' });
+            return res.status(400).json({ message: resp.err });
         } else if (resp) {
             return res.status(200).json({
                 message: "Success getting question!",

--- a/question-service/model/question-model.js
+++ b/question-service/model/question-model.js
@@ -11,6 +11,7 @@ let QuestionModelSchema = new Schema({
     },
     difficulty: {
         type: String,
+        enum: ['easy', 'medium', 'hard']
     },
     url: {
         type: String,

--- a/question-service/model/question-orm.js
+++ b/question-service/model/question-orm.js
@@ -22,6 +22,12 @@ export async function createOneQuestionModel(title, body, difficulty, url) {
 
 export async function getOneQuestionByDifficulty(difficulty) {
     try {
+        let diffEnum = ["easy", "medium", "hard"];
+        if (!diffEnum.includes(difficulty)) {
+            return {
+                err: "difficulty must be one of easy, medium or hard"
+            }
+        }
         const quesId = await randSelectQuestionId(difficulty);
         const ques = await getQuestionModelById(quesId);
         if (ques != null) {

--- a/question-service/model/question-orm.js
+++ b/question-service/model/question-orm.js
@@ -11,7 +11,7 @@ export async function createOneQuestionModel(title, body, difficulty, url) {
             difficulty: difficulty,
             url: url,
         });
-        newQues.save();
+        await newQues.save();
         return true;
 
     } catch (err) {


### PR DESCRIPTION
Closes #40 
history-service:
- sort by `updatedAt: desc` when returning histories for the user

question-service:
- add a contraint of difficulty {easy, medium, hard} when saving a new question
- add a check of difficulty {easy, medium, hard} when trying to get a question by difficulty. If difficulty is not one of {easy, medium, hard}, return error
- add postman collection

no changes required on frontend